### PR TITLE
Vmap restructure

### DIFF
--- a/src/python_tents.cpp
+++ b/src/python_tents.cpp
@@ -42,7 +42,6 @@ auto ExportTimeSlab(py::module &m)
 	 {
 	   int dim = self->ma->GetDimension();
 	   bool success = false;
-	   self->dt = dt;
 	   switch(dim){
 	   case 1:
 	     success = self->PitchTents<1>(dt,local_ct,global_ct);

--- a/src/tents.cpp
+++ b/src/tents.cpp
@@ -332,8 +332,6 @@ TentSlabPitcher::TentSlabPitcher(shared_ptr<MeshAccess> ama, ngstents::PitchingM
   if(method == ngstents::PitchingMethod::EEdgeGrad){ cmax.SetSize(ma->GetNEdges());}
   else {cmax.SetSize(ma->GetNE());}
   cmax = -1;
-  //map periodic vertices
-  MapPeriodicVertices();
 }
 
 
@@ -474,6 +472,8 @@ std::tuple<Table<int>,Table<int>> TentSlabPitcher::InitializeMeshData(LocalHeap 
             }
         }
     }
+  //map periodic vertices
+  MapPeriodicVertices();
   RemovePeriodicEdges(fine_edges);
   //compute neighbouring data
   TableCreator<int> create_v2e, create_v2v;
@@ -515,7 +515,7 @@ std::tuple<Table<int>,Table<int>> TentSlabPitcher::InitializeMeshData(LocalHeap 
   return std::make_tuple(v2v, v2e);
 }
 
-// Get the slave vertex elements for a master vertex in periodic case 3D
+// Get the slave vertex elements for a master vertex in periodic case
 void TentSlabPitcher::GetVertexElements(int vnr_master, Array<int> & elems)
 {
   ma->GetVertexElements (vnr_master, elems);
@@ -523,7 +523,6 @@ void TentSlabPitcher::GetVertexElements(int vnr_master, Array<int> & elems)
     return;
   else
     {
-      ma->GetVertexElements(vnr_master,elems);
       for(auto slave : slave_verts[vnr_master])
         for(auto elnr : ma->GetVertexElements(slave))
           elems.Append(elnr);

--- a/src/tents.hpp
+++ b/src/tents.hpp
@@ -112,20 +112,23 @@ namespace ngstents{
 }
 
 class TentPitchedSlab {
-public:
-  Array<Tent*> tents;         // tents between two time slices
-  double dt;                  // time step between two time slices
-  //wavespeed
-  shared_ptr<CoefficientFunction> cmax;
-  int nlayers;//number of layers in the time slab
-  //whether the slab has been already pitched
-  bool has_been_pitched;
-  LocalHeap lh;
+protected:
+  double dt;                              // time step between two time slices
+  shared_ptr<CoefficientFunction> cmax;   // wavespeed
   ngstents::PitchingMethod method;
+  bool has_been_pitched;                  // whether the slab has been already pitched
+  Array<Tent*> tents;                     // tents between two time slices
+  int nlayers;                            // number of layers in the time slab
 
-  
+  Array<int> vmap;                        // vertex map for periodic boundaries
+  LocalHeap lh;
+
+public:
   // access to base spatial mesh (public for export to Python visualization)
   shared_ptr<MeshAccess> ma;
+  // Propagate methods need access to DAG of tent dependencies
+  Table<int> tent_dependency;
+
   // Constructor and initializers
   TentPitchedSlab(shared_ptr<MeshAccess> ama, int heapsize) :
     dt(0), ma(ama), cmax(nullptr), nlayers(0),
@@ -143,7 +146,6 @@ public:
   int GetNTents() { return tents.Size(); }
   int GetNLayers() { return nlayers; }
 
-
   void SetWavespeed(const double c){cmax =  make_shared<ConstantCoefficientFunction>(c);}
   void SetWavespeed(shared_ptr<CoefficientFunction> c){ cmax = c;}
   
@@ -160,12 +162,6 @@ public:
                           Array<double> & tenttimes, int & nlevels);
 
   void SetPitchingMethod(ngstents::PitchingMethod amethod) {this->method = amethod;}
-
-  // Propagate methods need to access this somehow
-  Table<int> tent_dependency; // DAG of tent dependencies
-
-protected:
-  Array<int> vmap;
 };
 
 //Abstract class with the interface of methods used for pitching a tent


### PR DESCRIPTION
In the master version of the code, `vmap` is a static member of the `Tent` class. This would lead to conflicts as soon as more than one mesh is used for tent pitching in the same execution of the program.

This pull request addresses this issue. Now, `vmap` is a (non-static) member of the `TentPitchedSlab` class. Both the `TentSlabPitcher` and `Tent` classes have a reference to it. This change also allowed that the functions `GetVertexElements`, `MapPeriodicVertices` and `RemovePeriodicEdges` are now members of the `TentSlabPitcher` class, with minor modifications in their signature.

Comments:

At first, it was thought that it would suffice if `vmap` were a member of the `TentSlabPitcher` class and the `Tent` classes would have had a reference to it, however, the lifetime of a `TentSlabPitcher` instance is constrained to the moment in which the slab is being pitched, and `vmap` is needed later in the process, initializing the Finite Element Data.

Using a `shared_ptr` was considered, but since each `Tent` would need one shared_ptr as well, the reference counting (and the atomic operations it would lead to) has shown to be undesirable.