### PR TITLE
update to NGSolve-6.2.2105-132-g6388ee2f1

### DIFF
--- a/src/trefftz/__init__.py
+++ b/src/trefftz/__init__.py
@@ -31,7 +31,7 @@ def GetWave(self,U):
         u,v = fes.TnT()
         wavefront = self.GetWavefront()
         a = BilinearForm(fes)
-        a += SymbolicBFI(InnerProduct(u,v))
+        a += SymbolicBFI(u*v)
         a.Assemble()
 
         sirsize = int(wavefront.Width()/(D+1))

--- a/src/trefftz/diffopmapped.hpp
+++ b/src/trefftz/diffopmapped.hpp
@@ -267,9 +267,9 @@ namespace ngfem
                 Cast(fel).CalcMappedDShape (mip, Trans(mat));
             }
 
-            template <typename MAT>
+            template <typename SCALMIP, typename MAT>
             static void GenerateMatrix (const FiniteElement & fel,
-                    const MappedIntegrationPoint<D,D,Complex> & mip,
+                    const MappedIntegrationPoint<D,D,SCALMIP> & mip,
                     MAT && mat, LocalHeap & lh)
             {
                 HeapReset hr(lh);


### PR DESCRIPTION
fixes the compile error when using NGSolve >= 6.2.2105-132-g6388ee2f1